### PR TITLE
Various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
-## async-proxy-server
+# Async API Proxy Server
 
-Kaltura 'async-proxy-server' manages clients' api calls and forward them to kaltura api server in a speficic pase. Basically, This server is designed to cache api calls they are being call by same client constantly and handle to modes: aggregate a count for a specific call or hold only the last state of a specific call. After a TTL has passed the cached call should be sent to api server with the current data.
+The goal of this server is to cache API calls made by clients and only forward them to the Kaltura Server when certain conditions are met.
+
+## Main features:
+- Matches API calls against configuration templates to determine how they should be handled  
+- Supports different request types and response formats
+- Upon TTL expiry, will purge the cached API call and send it to the Kaltura server
+- Stores the sender IP as set in the for x-Forwarded-for header (only for ‘latest’ type of messages, not aggregation)
 
 ### Deployment
 Please refer to [deployment document] (https://github.com/kaltura/AsyncApiProxy/blob/master/async_proxy_server_deployment.md)

--- a/async_proxy_server_deployment.md
+++ b/async_proxy_server_deployment.md
@@ -18,13 +18,9 @@ The Async API Proxy Server requires [Kaltura Server](https://github.com/kaltura/
 ## Configuration
 1. Create a log directory (mkdir /opt/kaltura/log/asyncProxyServer)
 2. ln -s /opt/kaltura/asyncProxyServer/master /opt/kaltura/asyncProxyServer/latest
-    
 3. cp -p /opt/kaltura/asyncProxyServer/latest/config/default.template.json /opt/kaltura/asyncProxyServer/latest/config/default.json
 4. cp -p /opt/kaltura/asyncProxyServer/latest/bin/async-proxy-server.template.sh /opt/kaltura/asyncProxyServer/latest/bin/async-proxy-server.sh
-    
 5. ln -s /opt/kaltura/asyncProxyServer/latest/bin/async-proxy-server.sh /etc/init.d/kaltura_async_proxy
-6. ln -s /opt/kaltura/asyncProxyServer/latest/bin/upgrade-async-proxy-server.sh.sh /etc/init.d/kaltura_upgrade_async_proxy_server
-
 7. Replace the following tokens in default.json:
 ```
 @LOG_DIR@ - Your logs directory
@@ -42,13 +38,16 @@ The Async API Proxy Server requires [Kaltura Server](https://github.com/kaltura/
 
 9. Start the server:
 ```
-/etc/init.d/kaltura_async_proxy start
+# /etc/init.d/kaltura_async_proxy start
 ```
 You may also want to call chkconfig or update-rc.d so the daemon will be started during system init and stopped during shutdown.
 
 ## Upgrading
-run /etc/init.d/kaltura_upgrade_async_proxy_server @RELEASE_ID@
-Example to upgrade to 1.0 you need to execute: /etc/init.d/kaltura_upgrade_async_proxy_server 1.0
+run kaltura_upgrade_async_proxy_server @RELEASE_ID@
+For example, to upgrade to 1.0 you need to execute: 
+```
+# kaltura_upgrade_async_proxy_server 1.0
+```
 
 The upgrade will sync all the configuration files and will restart the service.
 Make sure that tokens in bin/async-proxy-server.sh file (ASYNC_PROXY_PATH and LOG_PATH) are pointing to the correct paths

--- a/async_proxy_server_deployment.md
+++ b/async_proxy_server_deployment.md
@@ -1,57 +1,54 @@
-Machine prerequisites:
-=======================
-	Git (For Ubuntu: https://www.digitalocean.com/community/tutorials/how-to-install-git-on-ubuntu-12-04)
-	Node 7.6.0 or above: installation reference: https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager#ubuntu-mint-elementary-os
-	Node Packaged Modules (npm) 1.4.3 or above
-	NVM version 0.30.1 or above
+# Async API Proxy Server (https://github.com/kaltura/AsyncApiProxy) Deployment Instructions
 
-Kaltura platform required changes:
-=======================
-	Please note that async-proxy-server needs version Lynx-12.14.0 at least for it to run. So if you are behind please update you Kaltura installation before continuing to any of the next steps.
+## Machine Prerequisites
+- Node 7.6.0 or above: installation reference: https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager#ubuntu-mint-elementary-os
+- Node Packaged Modules (npm) 1.4.3 or above
+- NVM version 0.30.1 or above
 
-Repo:
-=======================
-	https://github.com/kaltura/AsyncApiProxy
-
-Initial enviorment setup:
-=======================
-	1. Clone https://github.com/kaltura/AsyncApiProxy to /opt/kaltura/asyncProxyServer/master
-	2. Navigate to /opt/kaltura/asyncProxyServer/master
-	3. npm install
-	4. npm install -g forever
-
-Configure:
-=======================
-	1. Create a log directory (mkdir /opt/kaltura/log/asyncProxyServer)
-	2. ln -s /opt/kaltura/asyncProxyServer/master /opt/kaltura/asyncProxyServer/latest
-	 
-	3. cp -p /opt/kaltura/asyncProxyServer/latest/config/default.template.json /opt/kaltura/asyncProxyServer/latest/config/default.json
-	4. cp -p /opt/kaltura/asyncProxyServer/latest/bin/async-proxy-server.template.sh /opt/kaltura/asyncProxyServer/latest/bin/async-proxy-server.sh
-	 
-	5. ln -s /opt/kaltura/asyncProxyServer/latest/bin/async-proxy-server.sh /etc/init.d/kaltura_async_proxy
-	6. ln -s /opt/kaltura/asyncProxyServer/latest/bin/upgrade-async-proxy-server.sh.sh /etc/init.d/kaltura_upgrade_async_proxy_server
-
-Replace tokens in default.json file:
-=======================
-	@LOG_DIR@ - Your logs directory from previous step (e.g. /opt/kaltura/log/asyncProxyServer )
-	@WWW_HOST@ - Your API machine host
-	@http_port@ - HTTP port to run the server with
-	@https_por@ - HTTPS port to run the server with
-	@APP_REMOTE_ADDR_HEADER_SALT@ - Should be identical to "remote_addr_header_salt" configured in you Kaltura server configuration
-
-Replace tokens in async-proxy-server.sh file:
-=======================
-	@LOG_DIR@ - Your logs directory from previous step (e.g. /opt/kaltura/log/asyncProxyServer )
+*IMPORTANT NOTE: 
+The Async API Proxy Server requires [Kaltura Server](https://github.com/kaltura/server) of version Lynx-12.14.0 and above.*
 
 
-Execution:
-=======================
-	/etc/init.d/kaltura_async_proxy start
+## Initial Enviorment Setup
+1. Clone https://github.com/kaltura/AsyncApiProxy
+2. Navigate to the checkout dir
+3. npm install
+4. npm install -g forever
 
-Upgrade:
-=======================
-	run /etc/init.d/kaltura_upgrade_async_proxy_server @RELEASE_ID@
-	Example to upgrade to 1.0 you need to execute: /etc/init.d/kaltura_upgrade_async_proxy_server 1.0
-	 
-	The upgrade will sync all the configuration files and will restart the service.
-	Make sure that tokens in bin/async-proxy-server.sh file (ASYNC_PROXY_PATH and LOG_PATH) are pointing to the correct paths
+## Configuration
+1. Create a log directory (mkdir /opt/kaltura/log/asyncProxyServer)
+2. ln -s /opt/kaltura/asyncProxyServer/master /opt/kaltura/asyncProxyServer/latest
+    
+3. cp -p /opt/kaltura/asyncProxyServer/latest/config/default.template.json /opt/kaltura/asyncProxyServer/latest/config/default.json
+4. cp -p /opt/kaltura/asyncProxyServer/latest/bin/async-proxy-server.template.sh /opt/kaltura/asyncProxyServer/latest/bin/async-proxy-server.sh
+    
+5. ln -s /opt/kaltura/asyncProxyServer/latest/bin/async-proxy-server.sh /etc/init.d/kaltura_async_proxy
+6. ln -s /opt/kaltura/asyncProxyServer/latest/bin/upgrade-async-proxy-server.sh.sh /etc/init.d/kaltura_upgrade_async_proxy_server
+
+7. Replace the following tokens in default.json:
+```
+@LOG_DIR@ - Your logs directory
+@WWW_HOST@ - Your API machine host
+@HTTP_PORT@ - HTTP port to run the server with
+@HTTPS_PORT@ - HTTPS port to run the server with
+@APP_REMOTE_ADDR_HEADER_SALT@ - Should be identical to "remote_addr_header_salt" configured in you Kaltura Server configuration
+```
+
+8. Replace the following tokens in async-proxy-server.sh:
+```
+@ASYNC_API_PROXY_PREFIX@ - Async API Proxy prefix
+@LOG_DIR@ - Your logs directory
+```
+
+9. Start the server:
+```
+/etc/init.d/kaltura_async_proxy start
+```
+You may also want to call chkconfig or update-rc.d so the daemon will be started during system init and stopped during shutdown.
+
+## Upgrading
+run /etc/init.d/kaltura_upgrade_async_proxy_server @RELEASE_ID@
+Example to upgrade to 1.0 you need to execute: /etc/init.d/kaltura_upgrade_async_proxy_server 1.0
+
+The upgrade will sync all the configuration files and will restart the service.
+Make sure that tokens in bin/async-proxy-server.sh file (ASYNC_PROXY_PATH and LOG_PATH) are pointing to the correct paths

--- a/async_proxy_server_deployment.md
+++ b/async_proxy_server_deployment.md
@@ -1,4 +1,4 @@
-# Async API Proxy Server (https://github.com/kaltura/AsyncApiProxy) Deployment Instructions
+# [Async API Proxy Server](https://github.com/kaltura/AsyncApiProxy) Deployment Instructions
 
 ## Machine Prerequisites
 - Node 7.6.0 or above: installation reference: https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager#ubuntu-mint-elementary-os

--- a/async_proxy_server_deployment.md
+++ b/async_proxy_server_deployment.md
@@ -21,7 +21,7 @@ The Async API Proxy Server requires [Kaltura Server](https://github.com/kaltura/
 3. cp -p /opt/kaltura/asyncProxyServer/latest/config/default.template.json /opt/kaltura/asyncProxyServer/latest/config/default.json
 4. cp -p /opt/kaltura/asyncProxyServer/latest/bin/async-proxy-server.template.sh /opt/kaltura/asyncProxyServer/latest/bin/async-proxy-server.sh
 5. ln -s /opt/kaltura/asyncProxyServer/latest/bin/async-proxy-server.sh /etc/init.d/kaltura_async_proxy
-7. Replace the following tokens in default.json:
+6. Replace the following tokens in default.json:
 ```
 @LOG_DIR@ - Your logs directory
 @WWW_HOST@ - Your API machine host
@@ -30,24 +30,26 @@ The Async API Proxy Server requires [Kaltura Server](https://github.com/kaltura/
 @APP_REMOTE_ADDR_HEADER_SALT@ - Should be identical to "remote_addr_header_salt" configured in you Kaltura Server configuration
 ```
 
-8. Replace the following tokens in async-proxy-server.sh:
+7. Replace the following tokens in async-proxy-server.sh:
 ```
 @ASYNC_API_PROXY_PREFIX@ - Async API Proxy prefix
 @LOG_DIR@ - Your logs directory
 ```
 
-9. Start the server:
+8. Start the server:
 ```
 # /etc/init.d/kaltura_async_proxy start
 ```
 You may also want to call chkconfig or update-rc.d so the daemon will be started during system init and stopped during shutdown.
 
 ## Upgrading
-run kaltura_upgrade_async_proxy_server @RELEASE_ID@
+Run ```kaltura_upgrade_async_proxy_server @RELEASE_ID@```
+
 For example, to upgrade to 1.0 you need to execute: 
 ```
 # kaltura_upgrade_async_proxy_server 1.0
 ```
 
 The upgrade will sync all the configuration files and will restart the service.
+
 Make sure that tokens in bin/async-proxy-server.sh file (ASYNC_PROXY_PATH and LOG_PATH) are pointing to the correct paths

--- a/config/default.template.json
+++ b/config/default.template.json
@@ -8,7 +8,7 @@
   },
 
   "server": {
-    "version": "v1.0",
+    "version": "v1.0.0",
     "remote_addr_header_salt": "@APP_REMOTE_ADDR_HEADER_SALT@",
     "remote_addr_header_timeout": 120
   },
@@ -20,8 +20,8 @@
 
   "cloud": {
     "requestTimeout": 100000,
-    "httpPort": "@http_port@",
-    "httpsPort": "@https_port@"
+    "httpPort": "@HTTP_PORT@",
+    "httpsPort": "@HTTPS_PORT@"
   },
 
   "throttle": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
 	"name": "kaltura-async-proxy-server",
 	"description" : "Async Prxoy Server installation",
-	"version": "0.0.1",
+	"version": "1.0.0",
 	"engines" : { "node" : ">=7.6.0" },
 	"dependencies": {
-		"forever": ">=0.14.1",
 		"node-ini": ">=1.0.0",
 		"cron": ">=1.2.1",
 		"config": ">=1.25.1",


### PR DESCRIPTION
Init script:
- Check whether forever is installed and exit otherwise
- Use the @ASYNC_API_PROXY_PREFIX@ token for the prefix
- Use realpath when setting APPLICATION_PATH, otherwise, if you have a
    trailing '/' in ASYNC_PROXY_PATH, the status check will fail [forever list is soooo stupid]
- Use status() in logRotated()
- Set service display name as NAME
- Remove useless echo `date`

package.json:
- Remove dep on forever, it is only needed for the init script, plus,
    installing it locally under $ASYNC_PREFIX/node_modules/forever will not
    help the init script either
- Align the version string
config/default.json:
- fix version and upper case all tokens as is our standard

- README edits.