### PR TITLE
No-Plat: Avoid calling Object.keys on null in case requestExtraParams…

### DIFF
--- a/lib/ThrottleManager.js
+++ b/lib/ThrottleManager.js
@@ -71,6 +71,11 @@ class ThrottleManager {
 
     addExtraParams(request) {
         let requestExtraParams = request.requestExtraParams;
+        if(!requestExtraParams){
+            request.log("Request has no extra params");
+            return;
+        }
+
         Object.keys(requestExtraParams).forEach(function(key) {
             request.requestParams[key] = requestExtraParams[key];
         });


### PR DESCRIPTION
… is not defined